### PR TITLE
chore: export classes

### DIFF
--- a/packages/sdk/.gitignore
+++ b/packages/sdk/.gitignore
@@ -12,6 +12,7 @@ __pycache__
 # node
 node_modules/
 lib/
+dist/
 
 # hardhat / typechain artifacts
 cache/

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -11,9 +11,9 @@
     "windingtree",
     "markets"
   ],
-  "main": "./lib/cjs/index.js",
-  "module": "./lib/esm/index.js",
-  "types": "./lib/cjs/index.d.ts",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/cjs/index.d.ts",
   "scripts": {
     "typechain": "typechain --target ethers-v5 --glob './node_modules/@windingtree/videre-contracts/artifacts/**/*.json' --out-dir src/typechain",
     "protoc": "protoc --ts_out ./src/proto --proto_path ./src/proto ./src/proto/*.proto",
@@ -21,7 +21,7 @@
     "prepublish": "npm run typechain && npm run protoc && npm run tsc"
   },
   "files": [
-    "lib/"
+    "dist/"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@windingtree/videre-sdk",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Videre Protocol SDK",
   "author": "mfw78 <mfw78@protonmail.com>",
   "license": "MIT",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,6 +1,6 @@
-import type * as proto from "./proto";
-export type { proto }
-import type * as chain from "./typechain";
-export type { chain }
-import type * as utils from "./utils";
-export type { utils }
+import * as proto from "./proto";
+export { proto }
+import * as chain from "./typechain";
+export { chain }
+import * as utils from "./utils";
+export { utils }

--- a/packages/sdk/src/proto/index.ts
+++ b/packages/sdk/src/proto/index.ts
@@ -1,10 +1,10 @@
-import type * as bidask from "./bidask"
-export type { bidask }
-import type * as pingpong from "./pingpong"
-export type { pingpong }
-import type * as storage from "./storage"
-export type { storage }
-import type * as timestamp from "./timestamp"
-export type { timestamp }
-import type * as token from "./token"
-export type { token }
+import * as bidask from "./bidask"
+export { bidask }
+import * as pingpong from "./pingpong"
+export { pingpong }
+import * as storage from "./storage"
+export { storage }
+import * as timestamp from "./timestamp"
+export { timestamp }
+import * as token from "./token"
+export { token }

--- a/packages/sdk/tsconfig-cjs.json
+++ b/packages/sdk/tsconfig-cjs.json
@@ -2,6 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "CommonJS",
-    "outDir": "./lib/cjs"
+    "outDir": "./dist/cjs"
   },
 }

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -6,7 +6,7 @@
     "esModuleInterop": true,
     "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true,
-    "outDir": "./lib/esm",
+    "outDir": "./dist/esm",
     "declaration": true
   },
   "include": [


### PR DESCRIPTION
Only types were previously exported. This corrects that to include all exported items.