### PR TITLE
Storage protobufs

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -17,8 +17,9 @@
   "scripts": {
     "typechain": "typechain --target ethers-v5 --glob './node_modules/@windingtree/videre-contracts/artifacts/**/*.json' --out-dir src/typechain",
     "protoc": "protoc --ts_out ./src/proto --proto_path ./src/proto ./src/proto/*.proto",
+    "proto:source": "rm -rf ./dist/proto && mkdir ./dist/proto && cp -R ./src/proto/*.proto ./dist/proto/",
     "tsc": "tsc -p tsconfig.json && tsc -p tsconfig-cjs.json",
-    "prepublish": "npm run typechain && npm run protoc && npm run tsc",
+    "prepublish": "npm run typechain && npm run protoc && npm run tsc && npm run proto:source",
     "test": "mocha --loader=ts-node/esm --extension ts"
   },
   "files": [

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -39,7 +39,7 @@
     "@types/node": "^17.0.33",
     "@typescript-eslint/eslint-plugin": "^5.22.0",
     "@typescript-eslint/parser": "^5.22.0",
-    "@windingtree/videre-contracts": "^0.1.5",
+    "@windingtree/videre-contracts": "^0.1.6",
     "chai": "^4.3.6",
     "chai-ethers": "^0.0.1",
     "eslint": "^8.15.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -15,7 +15,7 @@
   "module": "./dist/esm/index.js",
   "types": "./dist/cjs/index.d.ts",
   "scripts": {
-    "typechain": "typechain --target ethers-v5 --glob './node_modules/@windingtree/videre-contracts/artifacts/**/*.json' --out-dir src/typechain",
+    "typechain": "typechain --target ethers-v5 --glob './node_modules/@windingtree/videre-contracts/artifacts/contracts/registries/ServiceProviderRegistry.sol/ServiceProviderRegistry.json' --out-dir ./src/typechain",
     "protoc": "protoc --ts_out ./src/proto --proto_path ./src/proto ./src/proto/*.proto",
     "proto:source": "rm -rf ./dist/proto && mkdir ./dist/proto && cp -R ./src/proto/*.proto ./dist/proto/",
     "tsc": "tsc -p tsconfig.json && tsc -p tsconfig-cjs.json",

--- a/packages/sdk/src/eip712/index.ts
+++ b/packages/sdk/src/eip712/index.ts
@@ -13,10 +13,24 @@ export {
   token
 }
 
-export async function validateProvider(
+/**
+ * Check if a signatory is valid for a service provider
+ * @param which service provider's signer is being validated
+ * @param role that the signer should possess
+ * @param who is claiming to be an authorized signer
+ * @param registry holding all valid service providers to check
+ * @returns true if a valid signer, false otherwise
+ */
+export async function validateSigner(
   which: Uint8Array,
+  role: number,
   who: string,
   registry: ServiceProviderRegistry
 ): Promise<boolean> {
-  return await registry.can(which, 3, who);
+  const roles = constants.AccessRoles
+  if (role != roles.API_ROLE || role != roles.BIDDER_ROLE) {
+    return new Promise((resolve) => resolve(false) )
+  } else {
+    return await registry.can(which, constants.AccessRoles.BIDDER_ROLE, who);
+  }
 }

--- a/packages/sdk/src/eip712/index.ts
+++ b/packages/sdk/src/eip712/index.ts
@@ -1,4 +1,5 @@
 import { ServiceProviderRegistry } from "../typechain"
+import { constants } from "../utils"
 import * as bidask from "./bidask"
 import * as pingpong from "./pingpong"
 import * as storage from "./storage"

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,8 +1,8 @@
 import * as proto from "./proto";
-export { proto }
-import * as chain from "./typechain";
-export { chain }
-import * as utils from "./utils";
-export { utils }
 import * as eip712 from "./eip712";
-export { eip712 }
+import * as utils from "./utils";
+export {
+  proto,
+  eip712,
+  utils
+}

--- a/packages/sdk/src/proto/storage.proto
+++ b/packages/sdk/src/proto/storage.proto
@@ -32,4 +32,6 @@ message ServiceProviderData {
   repeated ServiceItemData items = 2;
   // terms that may be applicable to services provided
   repeated ServiceTermData terms = 3;
+  // industry-specific payload describing service provider
+  bytes payload = 4;
 }

--- a/packages/sdk/src/utils/constants.ts
+++ b/packages/sdk/src/utils/constants.ts
@@ -1,0 +1,11 @@
+const AccessRoles = {
+  API_ROLE: 1,
+  BIDDER_ROLE: 2,
+  MANAGER_ROLE: 3,
+  STAFF_ROLE: 4,
+  WRITE_ROLE: 5
+}
+
+export {
+  AccessRoles
+}

--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -1,8 +1,9 @@
 import { verifyMessage, createSignedMessage, SignedMessage } from "./signing";
+import * as constants from "./constants"
 export type {
   SignedMessage
 }
 export { 
   verifyMessage,
-  createSignedMessage
- }
+  constants
+}

--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -5,5 +5,6 @@ export type {
 }
 export { 
   verifyMessage,
+  createSignedMessage,
   constants
 }

--- a/packages/sdk/yarn.lock
+++ b/packages/sdk/yarn.lock
@@ -588,10 +588,10 @@
   resolved "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
-"@windingtree/videre-contracts@^0.1.5":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@windingtree/videre-contracts/-/videre-contracts-0.1.5.tgz#9ecee1e63b3d0ae3096651b5bdbb55802d5c624b"
-  integrity sha512-XQQBE5tSohfk5ffyYEetwvazoGzYTVkFA2EoPzeH7r2q7zxgs1ESTVj63Nsg1RrYJZiiy4z43CTpr6KFxRsRAg==
+"@windingtree/videre-contracts@^0.1.6":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@windingtree/videre-contracts/-/videre-contracts-0.1.6.tgz#b73886944c1aa20aa5ec3ae81803dfdcb59c22fb"
+  integrity sha512-X/8me/jH6srJ0WR0A1nrXaiarQa9mg2PuMvQmmGJKVTaTgUUr1bGxz1Crnb9ham4vpk96LQj71AHkHU+OiVoSg==
   dependencies:
     "@openzeppelin/contracts" "^4.5.0"
 


### PR DESCRIPTION
Add missing `payload` to `ServiceProviderData` message. Allows for industry-specific implementation. Removed `typechain` export and added `videre` constants.