### PR TITLE
fix: 🐛 temporary optional sig on storage

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@windingtree/videre-sdk",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Videre Protocol SDK",
   "author": "mfw78 <mfw78@protonmail.com>",
   "license": "MIT",

--- a/packages/sdk/src/proto/storage.proto
+++ b/packages/sdk/src/proto/storage.proto
@@ -28,5 +28,5 @@ message ServiceProviderData {
   // industry-specific payload describing service provider
   bytes payload = 4;
   // signed hash by ServiceProvider `api` signer
-  bytes signature = 5;
+  optional bytes signature = 5;
 }


### PR DESCRIPTION
Allows for the ServiceProviderData signature to be optional so that unsigned protobufs may be sent to `lpms-server` and then signed by the API key there prior to upload.