### PR TITLE
fix: 🐛 impl should be string

### DIFF
--- a/packages/sdk/src/proto/bidask.proto
+++ b/packages/sdk/src/proto/bidask.proto
@@ -26,7 +26,7 @@ message BidTerm {
   // primitive term.id - terms by which the service is subject to
   bytes term = 1;
   // the contract address implementing ITerm
-  bytes impl = 2;
+  string impl = 2;
   // abi encoded payload that may be passed to a contract implementing ITerm
   optional bytes txPayload = 3;
 }


### PR DESCRIPTION
When doing EIP-712 type hashing, the `impl` is expected to be of type `string`.