### PR TITLE
Remove exporting of generated protobufs

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@windingtree/videre-sdk",
-  "version": "0.4.7",
+  "version": "0.5.0",
   "description": "Videre Protocol SDK",
   "author": "mfw78 <mfw78@protonmail.com>",
   "license": "MIT",
@@ -40,7 +40,7 @@
     "@types/node": "^17.0.33",
     "@typescript-eslint/eslint-plugin": "^5.22.0",
     "@typescript-eslint/parser": "^5.22.0",
-    "@windingtree/videre-contracts": "^0.1.6",
+    "@windingtree/videre-contracts": "^0.2.0-alpha.1",
     "chai": "^4.3.6",
     "chai-ethers": "^0.0.1",
     "eslint": "^8.15.0",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,10 +1,8 @@
 import * as chainstate from "./chainstate"
 import * as eip712 from "./eip712";
-import * as proto from "./proto";
 import * as utils from "./utils";
 export {
   chainstate,
   eip712,
-  proto,
   utils
 }

--- a/packages/sdk/yarn.lock
+++ b/packages/sdk/yarn.lock
@@ -588,10 +588,10 @@
   resolved "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
-"@windingtree/videre-contracts@^0.1.6":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@windingtree/videre-contracts/-/videre-contracts-0.1.6.tgz#b73886944c1aa20aa5ec3ae81803dfdcb59c22fb"
-  integrity sha512-X/8me/jH6srJ0WR0A1nrXaiarQa9mg2PuMvQmmGJKVTaTgUUr1bGxz1Crnb9ham4vpk96LQj71AHkHU+OiVoSg==
+"@windingtree/videre-contracts@^0.2.0-alpha.1":
+  version "0.2.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@windingtree/videre-contracts/-/videre-contracts-0.2.0-alpha.1.tgz#94c2f5a350e775f9d0c82364c51a5f7c02808aea"
+  integrity sha512-51q0tgv2gzOyGNob8NhlTUZaSWMempNX2vN+IB3JDSnl8UqUFpvsZRMI1iji9IVzjFMA9ZfhiQ3RZD6rfb+6VQ==
   dependencies:
     "@openzeppelin/contracts" "^4.5.0"
 


### PR DESCRIPTION
Removal of the generated protobufs. All downstream dependencies now must generate their own `typescript` from the packaged protobufs. This eliminates problems whereby upstream forgets to include type exports etc, leaving all types to be handled by the consuming package.