### PR TITLE
Fix/standardize throws

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@windingtree/videre-sdk",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Videre Protocol SDK",
   "author": "mfw78 <mfw78@protonmail.com>",
   "license": "MIT",

--- a/packages/sdk/src/utils/signing.ts
+++ b/packages/sdk/src/utils/signing.ts
@@ -4,9 +4,7 @@ import {
   TypedDataField
 } from '@ethersproject/abstract-signer';
 import { eip712 } from '..';
-import { BidOptions, BidTerm } from '../proto/bidask';
-
-const log = console.log;
+import { BidLine, BidOptions, BidTerm } from '../proto/bidask';
 
 export interface SignedMessage {
   signature: Uint8Array;
@@ -14,6 +12,7 @@ export interface SignedMessage {
 
 /**
  * Generics utility function for EIP712 signing of protobuf messages.
+ * @dev This method will throw if the EIP-712 signing fails
  * @param domain for EIP712 signature
  * @param types used within the data structure
  * @param msg being signed
@@ -36,6 +35,7 @@ export async function createSignedMessage<T extends SignedMessage>(
 
 /**
  * Generics utility function for verifying EIP712 signing of protobuf messages.
+ * @dev This method will eat the potential throw from `verifyTypedData`
  * @param which service provider to check on chain
  * @param domain for EIP712 signature verification
  * @param types used within the data structure
@@ -58,11 +58,27 @@ export async function verifyMessage<T extends SignedMessage, U>(
     // now pass the signer and value to a function to verify
     return verifier(which, who);
   } catch (e) {
-    log(e);
     return false;
   }
 }
 
+/**
+ * Create a BidLine message to convey a signed Bid
+ * @dev This method will throw if the EIP-712 signing fails
+ * @param domain The EIP-712 signing domain for the industry in which the bid is being made
+ * @param wallet that signs the bid
+ * @param salt from the `AskWrapper`
+ * @param which service provider this bid is being signed for
+ * @param params as a hashstruct of the Ask
+ * @param items that this bid is offering
+ * @param terms that this bid is offering
+ * @param options that this bid is offering
+ * @param limit number of times that this bid may be dealt
+ * @param expiry in unix epoch at which this bid becomes invalid
+ * @param gem the ERC20 token that this bid must be paid with if dealt
+ * @param wad the amount in atomic units of the ERC20 token that must pay for this bid
+ * @returns a signed BidLine
+ */
 export async function createBidLine(
   domain: TypedDataDomain,
   wallet: Wallet,
@@ -76,11 +92,11 @@ export async function createBidLine(
   expiry: number,
   gem: string,
   wad: BigNumber
-) {
+): Promise<BidLine> {
   return {
     limit: limit,
     expiry: expiry,
-    items: items,
+    items: items.map(v => utils.arrayify(v)),
     terms: terms,
     options: options,
     cost: [


### PR DESCRIPTION
This PR standardizes throwing in the `signing` utilities. Any signing function that returns a `boolean` (ie. to verify a message is signed by a valid key), then in the event the parameters passed are invalid, it will return false. Otherwise for all creation of signature methods, if the data passed is invalid, it will throw and is the job of the calling function to deal with the throw.

Closes #32 